### PR TITLE
Document added or dropped Python support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,12 @@
+Unreleased
+==========
+
+* add support for Python 3.6-3.9
+* drop support for Python 2.6-2.7, 3.3-3.5
+
+
 1.1.1
-=========
+=====
 
 * fix version determination (thanks @florimondmanca)
 
@@ -10,17 +17,19 @@
 - ci fixes
 
 1.0.1
-======
+=====
 
 pytest 5+ support
 
 1.0
-====
+===
 
 - re-sync with pylib codebase
+- add support for Python 3.4-3.5
+- drop support for Python 2.4-2.5, 3.2
 
 0.2
-==================
+===
 
 - added ability to ask "name in iniconfig", i.e. to check
   if a section is contained.


### PR DESCRIPTION
Fixes https://github.com/pytest-dev/iniconfig/issues/23.

* 2021-01-13: 3.9 added, 3.5 dropped https://github.com/pytest-dev/iniconfig/pull/25
* 2020-10-16: 2.6-2.7 and 3.3-3.4 dropped https://github.com/pytest-dev/iniconfig/pull/19
* 2020-10-14: 1.1.0 and 1.1.1 released https://pypi.org/project/iniconfig/#history
* ...
* 2016-09-23: 1.0.0 released https://pypi.org/project/iniconfig/#history
* 2016-09-23: 3.3-3.5 added, 2.4-2.5 and 3.1-3.2 dropped https://github.com/pytest-dev/iniconfig/commit/3ebb68c774c6a77bae76fe0018e7e626eee96e05#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449