### PR TITLE
Decode error in pytest.ini with chinese characters #5

### DIFF
--- a/src/iniconfig/__init__.py
+++ b/src/iniconfig/__init__.py
@@ -48,7 +48,7 @@ class IniConfig:
     def __init__(self, path, data=None):
         self.path = str(path)  # convenience
         if data is None:
-            f = open(self.path)
+            f = open(self.path, encoding='utf-8')
             try:
                 tokens = self._parse(iter(f))
             finally:

--- a/testing/test_iniconfig.py
+++ b/testing/test_iniconfig.py
@@ -296,3 +296,11 @@ def test_api_import():
 )
 def test_iscommentline_true(line):
     assert iscommentline(line)
+    
+def test_iniconfig_from_file_unicode(tmpdir):
+    path = tmpdir / "test_unicode.txt"
+    path.write("[data]\nvalue=A한다żółć,?/~äčď", encoding='utf-8')
+
+    config = IniConfig(path=path)
+    config["data"]["value"] == "A한다żółć,?/~äčď"
+


### PR DESCRIPTION
seems to fix Decode error in pytest.ini with chinese characters #5
https://github.com/pytest-dev/iniconfig/issues/5
