### PR TITLE
Add support for Python 3.11 and drop EOL 3.6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
             git fetch --prune --unshallow
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: deploy-${{ hashFiles('**/setup.py') }}
@@ -27,7 +27,7 @@ jobs:
             deploy-
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.x"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.x"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,9 @@ jobs:
             tox_env: "py311"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Install tox
@@ -41,6 +41,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+    - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
         include:
-          - python: "3.6"
-            tox_env: "py36"
           - python: "3.7"
             tox_env: "py37"
           - python: "3.8"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
         include:
           - python: "3.6"
@@ -23,6 +23,8 @@ jobs:
             tox_env: "py39"
           - python: "3.10"
             tox_env: "py310"
+          - python: "3.11"
+            tox_env: "py311"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,17 +12,6 @@ jobs:
       matrix:
         python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest]
-        include:
-          - python: "3.7"
-            tox_env: "py37"
-          - python: "3.8"
-            tox_env: "py38"
-          - python: "3.9"
-            tox_env: "py39"
-          - python: "3.10"
-            tox_env: "py310"
-          - python: "3.11"
-            tox_env: "py311"
 
     steps:
     - uses: actions/checkout@v3
@@ -36,7 +25,7 @@ jobs:
         pip install tox
     - name: Test
       run: |
-        tox -e ${{ matrix.tox_env }}
+        tox -e py
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,16 @@
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
+    rev: v3.2.0
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
 -   repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.19.0
+    rev: v2.2.0
     hooks:
     -   id: setup-cfg-fmt
+        args: [--include-version-classifiers, --min-py3-version=3.6]
 - repo: https://github.com/psf/black
-  rev: 21.10b0
+  rev: 22.10.0
   hooks:
       - id: black
         language_version: python3 # Should be a command that runs python3.6+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,14 @@ repos:
     rev: v3.2.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/setup-cfg-fmt
     rev: v2.2.0
     hooks:
     -   id: setup-cfg-fmt
-        args: [--include-version-classifiers, --min-py3-version=3.6]
+        args: [--include-version-classifiers]
 - repo: https://github.com/psf/black
   rev: 22.10.0
   hooks:
       - id: black
-        language_version: python3 # Should be a command that runs python3.6+
+        language_version: python3

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Libraries
     Topic :: Utilities
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Operating System :: POSIX
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -29,7 +28,7 @@ classifiers =
 
 [options]
 packages = iniconfig
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 package_dir = =src
 zip_safe = False

--- a/testing/test_iniconfig.py
+++ b/testing/test_iniconfig.py
@@ -1,4 +1,3 @@
-import py
 import pytest
 from iniconfig import IniConfig, ParseError, __all__ as ALL
 from iniconfig import iscommentline

--- a/testing/test_iniconfig.py
+++ b/testing/test_iniconfig.py
@@ -16,7 +16,7 @@ check_tokens = {
         [(0, None, "names", "Alice\nBob")],
     ),
     "value with aligned continuation": (
-        "names = Alice\n" "        Bob",
+        "names = Alice\n        Bob",
         [(0, None, "names", "Alice\nBob")],
     ),
     "blank line": (
@@ -141,7 +141,7 @@ def test_iniconfig_duplicate_key_fails():
 def test_iniconfig_lineof():
     config = IniConfig(
         "x.ini",
-        data=("[section]\n" "value = 1\n" "[section2]\n" "# comment\n" "value =2"),
+        data=("[section]\nvalue = 1\n[section2]\n# comment\nvalue =2"),
     )
 
     assert config.lineof("missing") is None

--- a/testing/test_iniconfig.py
+++ b/testing/test_iniconfig.py
@@ -63,7 +63,7 @@ def parse(input):
 
 
 def parse_a_error(input):
-    return py.test.raises(ParseError, parse, input)
+    return pytest.raises(ParseError, parse, input)
 
 
 def test_tokenize(input, expected):
@@ -98,7 +98,7 @@ def test_section_cant_be_empty():
     assert excinfo.value.lineno == 0
 
 
-@py.test.mark.parametrize(
+@pytest.mark.parametrize(
     "line",
     [
         "!!",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{36,37,38,39,310,311}
+envlist=py{37,38,39,310,311}
 isolated_build=True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{36,37,38,39,310}
+envlist=py{36,37,38,39,310,311}
 isolated_build=True
 
 [testenv]


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)

Also:

* Drop support for EOL Python 3.6
* Fix the build by renaming `py.test` to `pytest`
* Bump GitHub Actions and simplify config