### PR TITLE
Drop dependency on py

### DIFF
--- a/testing/test_iniconfig.py
+++ b/testing/test_iniconfig.py
@@ -1,4 +1,3 @@
-import py
 import pytest
 from iniconfig import IniConfig, ParseError, __all__ as ALL
 from iniconfig import iscommentline
@@ -63,7 +62,7 @@ def parse(input):
 
 
 def parse_a_error(input):
-    return py.test.raises(ParseError, parse, input)
+    return pytest.raises(ParseError, parse, input)
 
 
 def test_tokenize(input, expected):
@@ -98,7 +97,7 @@ def test_section_cant_be_empty():
     assert excinfo.value.lineno == 0
 
 
-@py.test.mark.parametrize(
+@pytest.mark.parametrize(
     "line",
     [
         "!!",


### PR DESCRIPTION
pytest 7.2 and tox 4 no longer depend on py and it's not needed here as well.