### PR TITLE
Use `pypa/gh-action-pypi-publish@release/v1` @ GHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Publish package to PyPI
         if: github.event.action == 'published'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
`master` has been sunset quite a while ago and points to a historic version. To use the latest stable release of this action, it should be `release/v1`. The TestPyPI upload uses the right step, but the PyPI one doesn't. This patch corrects that.