### PR TITLE
Include tests in sdist (fix #57)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ version-file = "src/iniconfig/_version.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/src",
+    "/testing",
 ]
 
 [tool.hatch.envs.test]


### PR DESCRIPTION
Re-include the `testing` folder in the sdist tarball that was present in the 1.x version but not in the 2.x version.