### PR TITLE
Remove unused typing imports to fix linting errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,21 @@
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.20.0
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: "0.4.1"
+  rev: "v2.6.0"
   hooks:
     - id: pyproject-fmt
 
 - repo: https://github.com/psf/black
-  rev: 22.12.0
+  rev: 25.1.0
   hooks:
       - id: black
         language_version: python3
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.991' 
+    rev: 'v1.17.0' 
     hooks:
     -   id: mypy
         args: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,33 +11,33 @@ description = "brain-dead simple config-ini parsing"
 readme = "README.rst"
 license = "MIT"
 authors = [
-    { name = "Ronny Pfannschmidt", email = "opensource@ronnypfannschmidt.de" },
-    { name = "Holger Krekel", email = "holger.krekel@gmail.com" },
+  { name = "Ronny Pfannschmidt", email = "opensource@ronnypfannschmidt.de" },
+  { name = "Holger Krekel", email = "holger.krekel@gmail.com" },
 ]
 requires-python = ">=3.8"
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: MacOS :: MacOS X",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: POSIX",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: Utilities",
+]
 dynamic = [
   "version",
 ]
-classifiers = [
-    "Development Status :: 4 - Beta",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: MacOS :: MacOS X",
-    "Operating System :: Microsoft :: Windows",
-    "Operating System :: POSIX",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Topic :: Software Development :: Libraries",
-    "Topic :: Utilities",
-]
-[project.urls]
-Homepage = "https://github.com/pytest-dev/iniconfig"
+urls.Homepage = "https://github.com/pytest-dev/iniconfig"
+
+[tool.setuptools_scm]
 
 [tool.hatch.version]
 source = "vcs"
@@ -47,24 +47,22 @@ version-file = "src/iniconfig/_version.py"
 
 [tool.hatch.build.targets.sdist]
 include = [
-    "/src",
-    "/testing",
+  "/src",
+  "/testing",
 ]
 
 [tool.hatch.envs.test]
 dependencies = [
-  "pytest"
+  "pytest",
 ]
 [tool.hatch.envs.test.scripts]
 default = "pytest {args}"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-
-[tool.setuptools_scm]
-
-[tool.mypy]
-strict = true
+python = [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
 [tool.pytest.ini_options]
 testpaths = "testing"
+
+[tool.mypy]
+strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/pytest-dev/iniconfig"
 
-
 [tool.hatch.version]
 source = "vcs"
 
@@ -66,7 +65,6 @@ python = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [tool.mypy]
 strict = true
-
 
 [tool.pytest.ini_options]
 testpaths = "testing"

--- a/src/iniconfig/__init__.py
+++ b/src/iniconfig/__init__.py
@@ -39,16 +39,14 @@ class SectionWrapper:
         return self.config.lineof(self.name, name)
 
     @overload
-    def get(self, key: str) -> str | None:
-        ...
+    def get(self, key: str) -> str | None: ...
 
     @overload
     def get(
         self,
         key: str,
         convert: Callable[[str], _T],
-    ) -> _T | None:
-        ...
+    ) -> _T | None: ...
 
     @overload
     def get(
@@ -56,12 +54,10 @@ class SectionWrapper:
         key: str,
         default: None,
         convert: Callable[[str], _T],
-    ) -> _T | None:
-        ...
+    ) -> _T | None: ...
 
     @overload
-    def get(self, key: str, default: _D, convert: None = None) -> str | _D:
-        ...
+    def get(self, key: str, default: _D, convert: None = None) -> str | _D: ...
 
     @overload
     def get(
@@ -69,8 +65,7 @@ class SectionWrapper:
         key: str,
         default: _D,
         convert: Callable[[str], _T],
-    ) -> _T | _D:
-        ...
+    ) -> _T | _D: ...
 
     # TODO: investigate possible mypy bug wrt matching the passed over data
     def get(  # type: ignore [misc]
@@ -143,8 +138,7 @@ class IniConfig:
         self,
         section: str,
         name: str,
-    ) -> str | None:
-        ...
+    ) -> str | None: ...
 
     @overload
     def get(
@@ -152,8 +146,7 @@ class IniConfig:
         section: str,
         name: str,
         convert: Callable[[str], _T],
-    ) -> _T | None:
-        ...
+    ) -> _T | None: ...
 
     @overload
     def get(
@@ -162,14 +155,12 @@ class IniConfig:
         name: str,
         default: None,
         convert: Callable[[str], _T],
-    ) -> _T | None:
-        ...
+    ) -> _T | None: ...
 
     @overload
     def get(
         self, section: str, name: str, default: _D, convert: None = None
-    ) -> str | _D:
-        ...
+    ) -> str | _D: ...
 
     @overload
     def get(
@@ -178,8 +169,7 @@ class IniConfig:
         name: str,
         default: _D,
         convert: Callable[[str], _T],
-    ) -> _T | _D:
-        ...
+    ) -> _T | _D: ...
 
     def get(  # type: ignore
         self,

--- a/src/iniconfig/__init__.py
+++ b/src/iniconfig/__init__.py
@@ -39,14 +39,16 @@ class SectionWrapper:
         return self.config.lineof(self.name, name)
 
     @overload
-    def get(self, key: str) -> str | None: ...
+    def get(self, key: str) -> str | None:
+        ...
 
     @overload
     def get(
         self,
         key: str,
         convert: Callable[[str], _T],
-    ) -> _T | None: ...
+    ) -> _T | None:
+        ...
 
     @overload
     def get(
@@ -54,10 +56,12 @@ class SectionWrapper:
         key: str,
         default: None,
         convert: Callable[[str], _T],
-    ) -> _T | None: ...
+    ) -> _T | None:
+        ...
 
     @overload
-    def get(self, key: str, default: _D, convert: None = None) -> str | _D: ...
+    def get(self, key: str, default: _D, convert: None = None) -> str | _D:
+        ...
 
     @overload
     def get(
@@ -65,7 +69,8 @@ class SectionWrapper:
         key: str,
         default: _D,
         convert: Callable[[str], _T],
-    ) -> _T | _D: ...
+    ) -> _T | _D:
+        ...
 
     # TODO: investigate possible mypy bug wrt matching the passed over data
     def get(  # type: ignore [misc]
@@ -138,7 +143,8 @@ class IniConfig:
         self,
         section: str,
         name: str,
-    ) -> str | None: ...
+    ) -> str | None:
+        ...
 
     @overload
     def get(
@@ -146,7 +152,8 @@ class IniConfig:
         section: str,
         name: str,
         convert: Callable[[str], _T],
-    ) -> _T | None: ...
+    ) -> _T | None:
+        ...
 
     @overload
     def get(
@@ -155,12 +162,14 @@ class IniConfig:
         name: str,
         default: None,
         convert: Callable[[str], _T],
-    ) -> _T | None: ...
+    ) -> _T | None:
+        ...
 
     @overload
     def get(
         self, section: str, name: str, default: _D, convert: None = None
-    ) -> str | _D: ...
+    ) -> str | _D:
+        ...
 
     @overload
     def get(
@@ -169,7 +178,8 @@ class IniConfig:
         name: str,
         default: _D,
         convert: Callable[[str], _T],
-    ) -> _T | _D: ...
+    ) -> _T | _D:
+        ...
 
     def get(  # type: ignore
         self,

--- a/src/iniconfig/__init__.py
+++ b/src/iniconfig/__init__.py
@@ -1,20 +1,15 @@
-""" brain-dead simple parser for ini-style files.
+"""brain-dead simple parser for ini-style files.
 (C) Ronny Pfannschmidt, Holger Krekel -- MIT licensed
 """
+
 from __future__ import annotations
 from typing import (
     Callable,
     Iterator,
     Mapping,
-    Optional,
-    Tuple,
     TypeVar,
-    Union,
     TYPE_CHECKING,
-    NoReturn,
-    NamedTuple,
     overload,
-    cast,
 )
 
 import os
@@ -44,16 +39,14 @@ class SectionWrapper:
         return self.config.lineof(self.name, name)
 
     @overload
-    def get(self, key: str) -> str | None:
-        ...
+    def get(self, key: str) -> str | None: ...
 
     @overload
     def get(
         self,
         key: str,
         convert: Callable[[str], _T],
-    ) -> _T | None:
-        ...
+    ) -> _T | None: ...
 
     @overload
     def get(
@@ -61,12 +54,10 @@ class SectionWrapper:
         key: str,
         default: None,
         convert: Callable[[str], _T],
-    ) -> _T | None:
-        ...
+    ) -> _T | None: ...
 
     @overload
-    def get(self, key: str, default: _D, convert: None = None) -> str | _D:
-        ...
+    def get(self, key: str, default: _D, convert: None = None) -> str | _D: ...
 
     @overload
     def get(
@@ -74,8 +65,7 @@ class SectionWrapper:
         key: str,
         default: _D,
         convert: Callable[[str], _T],
-    ) -> _T | _D:
-        ...
+    ) -> _T | _D: ...
 
     # TODO: investigate possible mypy bug wrt matching the passed over data
     def get(  # type: ignore [misc]
@@ -148,8 +138,7 @@ class IniConfig:
         self,
         section: str,
         name: str,
-    ) -> str | None:
-        ...
+    ) -> str | None: ...
 
     @overload
     def get(
@@ -157,8 +146,7 @@ class IniConfig:
         section: str,
         name: str,
         convert: Callable[[str], _T],
-    ) -> _T | None:
-        ...
+    ) -> _T | None: ...
 
     @overload
     def get(
@@ -167,14 +155,12 @@ class IniConfig:
         name: str,
         default: None,
         convert: Callable[[str], _T],
-    ) -> _T | None:
-        ...
+    ) -> _T | None: ...
 
     @overload
     def get(
         self, section: str, name: str, default: _D, convert: None = None
-    ) -> str | _D:
-        ...
+    ) -> str | _D: ...
 
     @overload
     def get(
@@ -183,8 +169,7 @@ class IniConfig:
         name: str,
         default: _D,
         convert: Callable[[str], _T],
-    ) -> _T | _D:
-        ...
+    ) -> _T | _D: ...
 
     def get(  # type: ignore
         self,


### PR DESCRIPTION
When developing with iniconfig, several linter messages appear that are quite annoying. This PR addresses these issues by fixing the linter errors, making the development experience smoother and cleaner. The changes maintain full compatibility while bringing the codebase in line with standard linting practices.